### PR TITLE
subtrack-label div accessible for click/mouseover

### DIFF
--- a/js/View/Track/MultiWiggle/MultiDensity.js
+++ b/js/View/Track/MultiWiggle/MultiDensity.js
@@ -92,7 +92,9 @@ function (
                             height: (kheight - 1) + 'px',
                             width: thisB.config.showLabels ? lw : '10px',
                             font: thisB.config.labelFont,
-                            backgroundColor: elt.color
+                            backgroundColor: elt.colorr,
+                            opacity: 0.2,
+                            'z-index':999
                         },
                         innerHTML: thisB.config.showLabels ? elt.name : ''
                     }, thisB.div);

--- a/js/View/Track/MultiWiggle/MultiDensity.js
+++ b/js/View/Track/MultiWiggle/MultiDensity.js
@@ -92,7 +92,7 @@ function (
                             height: (kheight - 1) + 'px',
                             width: thisB.config.showLabels ? lw : '10px',
                             font: thisB.config.labelFont,
-                            backgroundColor: elt.colorr,
+                            backgroundColor: elt.color,
                             opacity: 0.2,
                             'z-index':999
                         },


### PR DESCRIPTION
Tested with jbrowse 1.14.1 with google Chrome on ubuntu.  The Tooltip for MultiBigWig Density was not working.  Gave the div for the subtrack-label a high z-index.  Also set the opacity so to make the track data somewhat visible under the label